### PR TITLE
Move single files

### DIFF
--- a/src/test/java/de/borisskert/boxfs/filesystem/macos/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/macos/FileSystemTest.java
@@ -130,8 +130,24 @@ abstract class FileSystemTest {
 
             @Test
             void shouldFailWhenTryingToCopyNonExistingFile() {
-                assertThatThrownBy(() -> Files.copy(file, fs.getPath("target.txt")))
+                Path target = fs.getPath("target.txt");
+
+                assertThatThrownBy(() -> Files.copy(file, target))
                         .isInstanceOf(NoSuchFileException.class);
+
+                assertThat(Files.exists(file)).isFalse();
+                assertThat(Files.exists(target)).isFalse();
+            }
+
+            @Test
+            void shouldFailWhenTryingToMoveNonExistingFile() {
+                Path target = fs.getPath("target.txt");
+
+                assertThatThrownBy(() -> Files.move(file, target))
+                        .isInstanceOf(NoSuchFileException.class);
+
+                assertThat(Files.exists(file)).isFalse();
+                assertThat(Files.exists(target)).isFalse();
             }
 
             @Nested

--- a/src/test/java/de/borisskert/boxfs/filesystem/macos/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/macos/FileSystemTest.java
@@ -593,6 +593,14 @@ abstract class FileSystemTest {
                     void shouldFailWhenTryingToCopySecondFileToOtherWithoutReplace() {
                         assertThatThrownBy(() -> Files.copy(secondFile, file))
                                 .isInstanceOf(IOException.class);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
                     }
 
                     @Test
@@ -610,6 +618,19 @@ abstract class FileSystemTest {
                         assertThat(Files.isExecutable(file)).isFalse();
                         assertThat(Files.size(file)).isEqualTo(16L);
                         assertThat(Files.readAllBytes(file)).isEqualTo("Hello World! (2)".getBytes());
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.notExists(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
+                        assertThat(Files.isHidden(secondFile)).isFalse();
+                        assertThat(Files.isSymbolicLink(secondFile)).isFalse();
+                        assertThat(Files.isReadable(secondFile)).isTrue();
+                        assertThat(Files.isWritable(secondFile)).isTrue();
+                        assertThat(Files.isExecutable(secondFile)).isFalse();
+                        assertThat(Files.size(secondFile)).isEqualTo(16L);
+                        assertThat(Files.readAllBytes(secondFile)).isEqualTo("Hello World! (2)".getBytes());
+
                         assertThat(Files.isSameFile(file, secondFile)).isFalse();
                         assertThat(Files.isSameFile(file, file)).isTrue();
                         assertThat(file.toString()).isEqualTo(testFilePath);
@@ -619,6 +640,14 @@ abstract class FileSystemTest {
                     void shouldFailWhenTryingToCopyOtherFileToSecondWithoutReplace() {
                         assertThatThrownBy(() -> Files.copy(file, secondFile))
                                 .isInstanceOf(IOException.class);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
                     }
 
                     @Test
@@ -636,7 +665,124 @@ abstract class FileSystemTest {
                         assertThat(Files.isExecutable(secondFile)).isFalse();
                         assertThat(Files.size(secondFile)).isEqualTo(0L);
                         assertThat(Files.readAllBytes(secondFile)).isEqualTo(new byte[0]);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.notExists(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+                        assertThat(Files.isHidden(file)).isFalse();
+                        assertThat(Files.isSymbolicLink(file)).isFalse();
+                        assertThat(Files.isReadable(file)).isTrue();
+                        assertThat(Files.isWritable(file)).isTrue();
+                        assertThat(Files.isExecutable(file)).isFalse();
+                        assertThat(Files.size(file)).isEqualTo(0L);
+                        assertThat(Files.readAllBytes(file)).isEqualTo(new byte[0]);
+
                         assertThat(Files.isSameFile(secondFile, file)).isFalse();
+                        assertThat(Files.isSameFile(secondFile, secondFile)).isTrue();
+                        assertThat(secondFile.toString()).isEqualTo(secondFilePath);
+                    }
+
+                    @Test
+                    void shouldFailWhenTryingToMoveSecondFileToOtherWithoutReplace() {
+                        assertThatThrownBy(() -> Files.move(secondFile, file))
+                                .isInstanceOf(IOException.class);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
+                    }
+
+                    @Test
+                    void shouldMoveSecondFileToOtherWithReplace() throws IOException {
+                        Files.move(secondFile, file, REPLACE_EXISTING);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.notExists(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+                        assertThat(Files.isHidden(file)).isFalse();
+                        assertThat(Files.isSymbolicLink(file)).isFalse();
+                        assertThat(Files.isReadable(file)).isTrue();
+                        assertThat(Files.isWritable(file)).isTrue();
+                        assertThat(Files.isExecutable(file)).isFalse();
+                        assertThat(Files.size(file)).isEqualTo(16L);
+                        assertThat(Files.readAllBytes(file)).isEqualTo("Hello World! (2)".getBytes());
+
+                        assertThat(Files.exists(secondFile)).isFalse();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.notExists(secondFile)).isTrue();
+                        assertThat(Files.isRegularFile(secondFile)).isFalse();
+                        assertThat(Files.isHidden(secondFile)).isFalse();
+                        assertThat(Files.isSymbolicLink(secondFile)).isFalse();
+                        assertThat(Files.isReadable(secondFile)).isFalse();
+                        assertThat(Files.isWritable(secondFile)).isFalse();
+                        assertThat(Files.isExecutable(secondFile)).isFalse();
+                        assertThatThrownBy(() -> Files.size(secondFile))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThatThrownBy(() -> Files.readAllBytes(secondFile)).
+                                isInstanceOf(NoSuchFileException.class);
+
+                        assertThatThrownBy(() -> Files.isSameFile(file, secondFile))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThatThrownBy(() -> Files.isSameFile(secondFile, file))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThat(Files.isSameFile(file, file)).isTrue();
+                        assertThat(file.toString()).isEqualTo(testFilePath);
+                    }
+
+                    @Test
+                    void shouldFailWhenTryingToMoveOtherFileToSecondWithoutReplace() {
+                        assertThatThrownBy(() -> Files.move(file, secondFile))
+                                .isInstanceOf(IOException.class);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
+                    }
+
+                    @Test
+                    void shouldMoveOtherFileToSecondWithReplace() throws IOException {
+                        Files.move(file, secondFile, REPLACE_EXISTING);
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.notExists(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
+                        assertThat(Files.isHidden(secondFile)).isFalse();
+                        assertThat(Files.isSymbolicLink(secondFile)).isFalse();
+                        assertThat(Files.isReadable(secondFile)).isTrue();
+                        assertThat(Files.isWritable(secondFile)).isTrue();
+                        assertThat(Files.isExecutable(secondFile)).isFalse();
+                        assertThat(Files.size(secondFile)).isEqualTo(0L);
+                        assertThat(Files.readAllBytes(secondFile)).isEqualTo(new byte[0]);
+
+                        assertThat(Files.exists(file)).isFalse();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.notExists(file)).isTrue();
+                        assertThat(Files.isRegularFile(file)).isFalse();
+                        assertThat(Files.isHidden(file)).isFalse();
+                        assertThat(Files.isSymbolicLink(file)).isFalse();
+                        assertThat(Files.isReadable(file)).isFalse();
+                        assertThat(Files.isWritable(file)).isFalse();
+                        assertThat(Files.isExecutable(file)).isFalse();
+                        assertThatThrownBy(() -> Files.size(file))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThatThrownBy(() -> Files.readAllBytes(file)).
+                                isInstanceOf(NoSuchFileException.class);
+
+                        assertThatThrownBy(() -> Files.isSameFile(secondFile, file))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThatThrownBy(() -> Files.isSameFile(file, secondFile))
+                                .isInstanceOf(NoSuchFileException.class);
                         assertThat(Files.isSameFile(secondFile, secondFile)).isTrue();
                         assertThat(secondFile.toString()).isEqualTo(secondFilePath);
                     }

--- a/src/test/java/de/borisskert/boxfs/filesystem/macos/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/macos/FileSystemTest.java
@@ -408,6 +408,58 @@ abstract class FileSystemTest {
                     assertThat(file.toString()).isEqualTo(testFilePath);
                 }
 
+                @Nested
+                class MoveFileToAbsoluteSimpleTarget {
+                    private Path target;
+
+                    @BeforeEach
+                    void setup() throws IOException {
+                        target = fs.getPath("/target.txt");
+                        Files.write(file, "Hello World!".getBytes());
+                    }
+
+                    @AfterEach
+                    void teardown() throws IOException {
+                        Files.deleteIfExists(target);
+                    }
+
+                    @Test
+                    void shouldMoveFile() throws IOException {
+                        Files.move(file, target);
+
+                        assertThat(Files.exists(target)).isTrue();
+                        assertThat(Files.readAllBytes(target)).isEqualTo("Hello World!".getBytes());
+
+                        assertThat(Files.exists(file)).isFalse();
+                    }
+                }
+
+                @Nested
+                class MoveFileToRelativeSimpleTarget {
+                    private Path target;
+
+                    @BeforeEach
+                    void setup() throws IOException {
+                        target = fs.getPath("target.txt");
+                        Files.write(file, "Hello World!".getBytes());
+                    }
+
+                    @AfterEach
+                    void teardown() throws IOException {
+                        Files.deleteIfExists(target);
+                    }
+
+                    @Test
+                    void shouldMoveFile() throws IOException {
+                        Files.move(file, target);
+
+                        assertThat(Files.exists(target)).isTrue();
+                        assertThat(Files.readAllBytes(target)).isEqualTo("Hello World!".getBytes());
+
+                        assertThat(Files.exists(file)).isFalse();
+                    }
+                }
+
                 @Test
                 @Disabled
                 void shouldNotBeAbleToGetDosFilePermissions() {

--- a/src/test/java/de/borisskert/boxfs/filesystem/macos/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/macos/FileSystemTest.java
@@ -477,6 +477,24 @@ abstract class FileSystemTest {
                 }
 
                 @Test
+                void shouldNotDoAnythingWhenMoveEmptyFileToSameTarget() throws IOException {
+                    Files.move(file, file);
+
+                    assertThat(Files.exists(file)).isTrue();
+                    assertThat(Files.isDirectory(file)).isFalse();
+                    assertThat(Files.notExists(file)).isFalse();
+                    assertThat(Files.isRegularFile(file)).isTrue();
+                    assertThat(Files.isHidden(file)).isFalse();
+                    assertThat(Files.isSymbolicLink(file)).isFalse();
+                    assertThat(Files.isReadable(file)).isTrue();
+                    assertThat(Files.isWritable(file)).isTrue();
+                    assertThat(Files.isExecutable(file)).isFalse();
+                    assertThat(Files.size(file)).isEqualTo(0L);
+                    assertThat(Files.isSameFile(file, file)).isTrue();
+                    assertThat(file.toString()).isEqualTo(testFilePath);
+                }
+
+                @Test
                 @Disabled
                 void shouldNotBeAbleToGetDosFilePermissions() {
                     assertThatThrownBy(() -> Files.getAttribute(file, "dos:readonly")).isInstanceOf(UnsupportedOperationException.class);

--- a/src/test/java/de/borisskert/boxfs/filesystem/unix/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/unix/FileSystemTest.java
@@ -130,8 +130,24 @@ abstract class FileSystemTest {
 
             @Test
             void shouldFailWhenTryingToCopyNonExistingFile() {
-                assertThatThrownBy(() -> Files.copy(file, fs.getPath("target.txt")))
+                Path target = fs.getPath("target.txt");
+
+                assertThatThrownBy(() -> Files.copy(file, target))
                         .isInstanceOf(NoSuchFileException.class);
+
+                assertThat(Files.exists(file)).isFalse();
+                assertThat(Files.exists(target)).isFalse();
+            }
+
+            @Test
+            void shouldFailWhenTryingToMoveNonExistingFile() {
+                Path target = fs.getPath("target.txt");
+
+                assertThatThrownBy(() -> Files.move(file, target))
+                        .isInstanceOf(NoSuchFileException.class);
+
+                assertThat(Files.exists(file)).isFalse();
+                assertThat(Files.exists(target)).isFalse();
             }
 
             @Nested

--- a/src/test/java/de/borisskert/boxfs/filesystem/unix/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/unix/FileSystemTest.java
@@ -603,6 +603,14 @@ abstract class FileSystemTest {
                     void shouldFailWhenTryingToCopySecondFileToOtherWithoutReplace() {
                         assertThatThrownBy(() -> Files.copy(secondFile, file))
                                 .isInstanceOf(IOException.class);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
                     }
 
                     @Test
@@ -620,6 +628,19 @@ abstract class FileSystemTest {
                         assertThat(Files.isExecutable(file)).isFalse();
                         assertThat(Files.size(file)).isEqualTo(16L);
                         assertThat(Files.readAllBytes(file)).isEqualTo("Hello World! (2)".getBytes());
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.notExists(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
+                        assertThat(Files.isHidden(secondFile)).isFalse();
+                        assertThat(Files.isSymbolicLink(secondFile)).isFalse();
+                        assertThat(Files.isReadable(secondFile)).isTrue();
+                        assertThat(Files.isWritable(secondFile)).isTrue();
+                        assertThat(Files.isExecutable(secondFile)).isFalse();
+                        assertThat(Files.size(secondFile)).isEqualTo(16L);
+                        assertThat(Files.readAllBytes(secondFile)).isEqualTo("Hello World! (2)".getBytes());
+
                         assertThat(Files.isSameFile(file, secondFile)).isFalse();
                         assertThat(Files.isSameFile(file, file)).isTrue();
                         assertThat(file.toString()).isEqualTo(testFilePath);
@@ -629,6 +650,14 @@ abstract class FileSystemTest {
                     void shouldFailWhenTryingToCopyOtherFileToSecondWithoutReplace() {
                         assertThatThrownBy(() -> Files.copy(file, secondFile))
                                 .isInstanceOf(IOException.class);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
                     }
 
                     @Test
@@ -646,7 +675,124 @@ abstract class FileSystemTest {
                         assertThat(Files.isExecutable(secondFile)).isFalse();
                         assertThat(Files.size(secondFile)).isEqualTo(0L);
                         assertThat(Files.readAllBytes(secondFile)).isEqualTo(new byte[0]);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.notExists(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+                        assertThat(Files.isHidden(file)).isFalse();
+                        assertThat(Files.isSymbolicLink(file)).isFalse();
+                        assertThat(Files.isReadable(file)).isTrue();
+                        assertThat(Files.isWritable(file)).isTrue();
+                        assertThat(Files.isExecutable(file)).isFalse();
+                        assertThat(Files.size(file)).isEqualTo(0L);
+                        assertThat(Files.readAllBytes(file)).isEqualTo(new byte[0]);
+
                         assertThat(Files.isSameFile(secondFile, file)).isFalse();
+                        assertThat(Files.isSameFile(secondFile, secondFile)).isTrue();
+                        assertThat(secondFile.toString()).isEqualTo(secondFilePath);
+                    }
+
+                    @Test
+                    void shouldFailWhenTryingToMoveSecondFileToOtherWithoutReplace() {
+                        assertThatThrownBy(() -> Files.move(secondFile, file))
+                                .isInstanceOf(IOException.class);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
+                    }
+
+                    @Test
+                    void shouldMoveSecondFileToOtherWithReplace() throws IOException {
+                        Files.move(secondFile, file, REPLACE_EXISTING);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.notExists(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+                        assertThat(Files.isHidden(file)).isFalse();
+                        assertThat(Files.isSymbolicLink(file)).isFalse();
+                        assertThat(Files.isReadable(file)).isTrue();
+                        assertThat(Files.isWritable(file)).isTrue();
+                        assertThat(Files.isExecutable(file)).isFalse();
+                        assertThat(Files.size(file)).isEqualTo(16L);
+                        assertThat(Files.readAllBytes(file)).isEqualTo("Hello World! (2)".getBytes());
+
+                        assertThat(Files.exists(secondFile)).isFalse();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.notExists(secondFile)).isTrue();
+                        assertThat(Files.isRegularFile(secondFile)).isFalse();
+                        assertThat(Files.isHidden(secondFile)).isFalse();
+                        assertThat(Files.isSymbolicLink(secondFile)).isFalse();
+                        assertThat(Files.isReadable(secondFile)).isFalse();
+                        assertThat(Files.isWritable(secondFile)).isFalse();
+                        assertThat(Files.isExecutable(secondFile)).isFalse();
+                        assertThatThrownBy(() -> Files.size(secondFile))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThatThrownBy(() -> Files.readAllBytes(secondFile)).
+                                isInstanceOf(NoSuchFileException.class);
+
+                        assertThatThrownBy(() -> Files.isSameFile(file, secondFile))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThatThrownBy(() -> Files.isSameFile(secondFile, file))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThat(Files.isSameFile(file, file)).isTrue();
+                        assertThat(file.toString()).isEqualTo(testFilePath);
+                    }
+
+                    @Test
+                    void shouldFailWhenTryingToMoveOtherFileToSecondWithoutReplace() {
+                        assertThatThrownBy(() -> Files.move(file, secondFile))
+                                .isInstanceOf(IOException.class);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
+                    }
+
+                    @Test
+                    void shouldMoveOtherFileToSecondWithReplace() throws IOException {
+                        Files.move(file, secondFile, REPLACE_EXISTING);
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.notExists(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
+                        assertThat(Files.isHidden(secondFile)).isFalse();
+                        assertThat(Files.isSymbolicLink(secondFile)).isFalse();
+                        assertThat(Files.isReadable(secondFile)).isTrue();
+                        assertThat(Files.isWritable(secondFile)).isTrue();
+                        assertThat(Files.isExecutable(secondFile)).isFalse();
+                        assertThat(Files.size(secondFile)).isEqualTo(0L);
+                        assertThat(Files.readAllBytes(secondFile)).isEqualTo(new byte[0]);
+
+                        assertThat(Files.exists(file)).isFalse();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.notExists(file)).isTrue();
+                        assertThat(Files.isRegularFile(file)).isFalse();
+                        assertThat(Files.isHidden(file)).isFalse();
+                        assertThat(Files.isSymbolicLink(file)).isFalse();
+                        assertThat(Files.isReadable(file)).isFalse();
+                        assertThat(Files.isWritable(file)).isFalse();
+                        assertThat(Files.isExecutable(file)).isFalse();
+                        assertThatThrownBy(() -> Files.size(file))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThatThrownBy(() -> Files.readAllBytes(file)).
+                                isInstanceOf(NoSuchFileException.class);
+
+                        assertThatThrownBy(() -> Files.isSameFile(secondFile, file))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThatThrownBy(() -> Files.isSameFile(file, secondFile))
+                                .isInstanceOf(NoSuchFileException.class);
                         assertThat(Files.isSameFile(secondFile, secondFile)).isTrue();
                         assertThat(secondFile.toString()).isEqualTo(secondFilePath);
                     }

--- a/src/test/java/de/borisskert/boxfs/filesystem/unix/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/unix/FileSystemTest.java
@@ -418,6 +418,58 @@ abstract class FileSystemTest {
                     assertThat(file.toString()).isEqualTo(testFilePath);
                 }
 
+                @Nested
+                class MoveFileToAbsoluteSimpleTarget {
+                    private Path target;
+
+                    @BeforeEach
+                    void setup() throws IOException {
+                        target = fs.getPath("/target.txt");
+                        Files.write(file, "Hello World!".getBytes());
+                    }
+
+                    @AfterEach
+                    void teardown() throws IOException {
+                        Files.deleteIfExists(target);
+                    }
+
+                    @Test
+                    void shouldMoveFile() throws IOException {
+                        Files.move(file, target);
+
+                        assertThat(Files.exists(target)).isTrue();
+                        assertThat(Files.readAllBytes(target)).isEqualTo("Hello World!".getBytes());
+
+                        assertThat(Files.exists(file)).isFalse();
+                    }
+                }
+
+                @Nested
+                class MoveFileToRelativeSimpleTarget {
+                    private Path target;
+
+                    @BeforeEach
+                    void setup() throws IOException {
+                        target = fs.getPath("target.txt");
+                        Files.write(file, "Hello World!".getBytes());
+                    }
+
+                    @AfterEach
+                    void teardown() throws IOException {
+                        Files.deleteIfExists(target);
+                    }
+
+                    @Test
+                    void shouldMoveFile() throws IOException {
+                        Files.move(file, target);
+
+                        assertThat(Files.exists(target)).isTrue();
+                        assertThat(Files.readAllBytes(target)).isEqualTo("Hello World!".getBytes());
+
+                        assertThat(Files.exists(file)).isFalse();
+                    }
+                }
+
                 @Test
                 @Disabled
                 void shouldNotBeAbleToGetDosFilePermissions() {

--- a/src/test/java/de/borisskert/boxfs/filesystem/unix/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/unix/FileSystemTest.java
@@ -487,6 +487,24 @@ abstract class FileSystemTest {
                 }
 
                 @Test
+                void shouldNotDoAnythingWhenMoveEmptyFileToSameTarget() throws IOException {
+                    Files.move(file, file);
+
+                    assertThat(Files.exists(file)).isTrue();
+                    assertThat(Files.isDirectory(file)).isFalse();
+                    assertThat(Files.notExists(file)).isFalse();
+                    assertThat(Files.isRegularFile(file)).isTrue();
+                    assertThat(Files.isHidden(file)).isFalse();
+                    assertThat(Files.isSymbolicLink(file)).isFalse();
+                    assertThat(Files.isReadable(file)).isTrue();
+                    assertThat(Files.isWritable(file)).isTrue();
+                    assertThat(Files.isExecutable(file)).isFalse();
+                    assertThat(Files.size(file)).isEqualTo(0L);
+                    assertThat(Files.isSameFile(file, file)).isTrue();
+                    assertThat(file.toString()).isEqualTo(testFilePath);
+                }
+
+                @Test
                 @Disabled
                 void shouldNotBeAbleToGetDosFilePermissions() {
                     assertThatThrownBy(() -> Files.getAttribute(file, "dos:readonly")).isInstanceOf(UnsupportedOperationException.class);

--- a/src/test/java/de/borisskert/boxfs/filesystem/windows/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/windows/FileSystemTest.java
@@ -592,35 +592,17 @@ abstract class FileSystemTest {
                     }
 
                     @Test
-                    void shouldFailWhenTryingToCopySecondFileToOtherWithoutReplace() {
-                        assertThatThrownBy(() -> Files.copy(secondFile, file))
-                                .isInstanceOf(IOException.class);
-                    }
-
-                    @Test
-                    void shouldCopySecondFileToOtherWithReplace() throws IOException {
-                        Files.copy(secondFile, file, REPLACE_EXISTING);
-
-                        assertThat(Files.exists(file)).isTrue();
-                        assertThat(Files.isDirectory(file)).isFalse();
-                        assertThat(Files.notExists(file)).isFalse();
-                        assertThat(Files.isRegularFile(file)).isTrue();
-                        assertThat(Files.isHidden(file)).isFalse();
-                        assertThat(Files.isSymbolicLink(file)).isFalse();
-                        assertThat(Files.isReadable(file)).isTrue();
-                        assertThat(Files.isWritable(file)).isTrue();
-                        assertThat(Files.isExecutable(file)).isTrue();
-                        assertThat(Files.size(file)).isEqualTo(16L);
-                        assertThat(Files.readAllBytes(file)).isEqualTo("Hello World! (2)".getBytes());
-                        assertThat(Files.isSameFile(file, secondFile)).isFalse();
-                        assertThat(Files.isSameFile(file, file)).isTrue();
-                        assertThat(file.toString()).isEqualTo(testFilePath);
-                    }
-
-                    @Test
                     void shouldFailWhenTryingToCopyOtherFileToSecondWithoutReplace() {
                         assertThatThrownBy(() -> Files.copy(file, secondFile))
                                 .isInstanceOf(IOException.class);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
                     }
 
                     @Test
@@ -638,7 +620,126 @@ abstract class FileSystemTest {
                         assertThat(Files.isExecutable(secondFile)).isTrue();
                         assertThat(Files.size(secondFile)).isEqualTo(0L);
                         assertThat(Files.readAllBytes(secondFile)).isEqualTo(new byte[0]);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.notExists(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+                        assertThat(Files.isHidden(file)).isFalse();
+                        assertThat(Files.isSymbolicLink(file)).isFalse();
+                        assertThat(Files.isReadable(file)).isTrue();
+                        assertThat(Files.isWritable(file)).isTrue();
+                        assertThat(Files.isExecutable(file)).isTrue();
+                        assertThat(Files.size(file)).isEqualTo(0L);
+                        assertThat(Files.readAllBytes(file)).isEqualTo(new byte[0]);
+
                         assertThat(Files.isSameFile(secondFile, file)).isFalse();
+                        assertThat(Files.isSameFile(secondFile, secondFile)).isTrue();
+                        assertThat(secondFile.toString()).isEqualTo(secondFilePath);
+                    }
+
+                    @Test
+                    void shouldFailWhenTryingToMoveSecondFileToOtherWithoutReplace() {
+                        assertThatThrownBy(() -> Files.move(secondFile, file))
+                                .isInstanceOf(IOException.class);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
+                    }
+
+                    @Test
+                    void shouldMoveSecondFileToOtherWithReplace() throws IOException {
+                        Files.move(secondFile, file, REPLACE_EXISTING);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.notExists(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+                        assertThat(Files.isHidden(file)).isFalse();
+                        assertThat(Files.isSymbolicLink(file)).isFalse();
+                        assertThat(Files.isReadable(file)).isTrue();
+                        assertThat(Files.isWritable(file)).isTrue();
+                        assertThat(Files.isExecutable(file)).isTrue();
+                        assertThat(Files.size(file)).isEqualTo(16L);
+                        assertThat(Files.readAllBytes(file)).isEqualTo("Hello World! (2)".getBytes());
+
+                        assertThat(Files.exists(secondFile)).isFalse();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.notExists(secondFile)).isTrue();
+                        assertThat(Files.isRegularFile(secondFile)).isFalse();
+                        assertThatThrownBy(() -> Files.isHidden(secondFile))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThat(Files.isSymbolicLink(secondFile)).isFalse();
+                        assertThat(Files.isReadable(secondFile)).isFalse();
+                        assertThat(Files.isWritable(secondFile)).isFalse();
+                        assertThat(Files.isExecutable(secondFile)).isFalse();
+                        assertThatThrownBy(() -> Files.size(secondFile))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThatThrownBy(() -> Files.readAllBytes(secondFile)).
+                                isInstanceOf(NoSuchFileException.class);
+
+                        assertThatThrownBy(() -> Files.isSameFile(file, secondFile))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThatThrownBy(() -> Files.isSameFile(secondFile, file))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThat(Files.isSameFile(file, file)).isTrue();
+                        assertThat(file.toString()).isEqualTo(testFilePath);
+                    }
+
+                    @Test
+                    void shouldFailWhenTryingToMoveOtherFileToSecondWithoutReplace() {
+                        assertThatThrownBy(() -> Files.move(file, secondFile))
+                                .isInstanceOf(IOException.class);
+
+                        assertThat(Files.exists(file)).isTrue();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.isRegularFile(file)).isTrue();
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
+                    }
+
+                    @Test
+                    void shouldMoveOtherFileToSecondWithReplace() throws IOException {
+                        Files.move(file, secondFile, REPLACE_EXISTING);
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.isDirectory(secondFile)).isFalse();
+                        assertThat(Files.notExists(secondFile)).isFalse();
+                        assertThat(Files.isRegularFile(secondFile)).isTrue();
+                        assertThat(Files.isHidden(secondFile)).isFalse();
+                        assertThat(Files.isSymbolicLink(secondFile)).isFalse();
+                        assertThat(Files.isReadable(secondFile)).isTrue();
+                        assertThat(Files.isWritable(secondFile)).isTrue();
+                        assertThat(Files.isExecutable(secondFile)).isTrue();
+                        assertThat(Files.size(secondFile)).isEqualTo(0L);
+                        assertThat(Files.readAllBytes(secondFile)).isEqualTo(new byte[0]);
+
+                        assertThat(Files.exists(file)).isFalse();
+                        assertThat(Files.isDirectory(file)).isFalse();
+                        assertThat(Files.notExists(file)).isTrue();
+                        assertThat(Files.isRegularFile(file)).isFalse();
+                        assertThatThrownBy(() -> Files.isHidden(file))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThat(Files.isSymbolicLink(file)).isFalse();
+                        assertThat(Files.isReadable(file)).isFalse();
+                        assertThat(Files.isWritable(file)).isFalse();
+                        assertThat(Files.isExecutable(file)).isFalse();
+                        assertThatThrownBy(() -> Files.size(file))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThatThrownBy(() -> Files.readAllBytes(file)).
+                                isInstanceOf(NoSuchFileException.class);
+
+                        assertThatThrownBy(() -> Files.isSameFile(secondFile, file))
+                                .isInstanceOf(NoSuchFileException.class);
+                        assertThatThrownBy(() -> Files.isSameFile(file, secondFile))
+                                .isInstanceOf(NoSuchFileException.class);
                         assertThat(Files.isSameFile(secondFile, secondFile)).isTrue();
                         assertThat(secondFile.toString()).isEqualTo(secondFilePath);
                     }

--- a/src/test/java/de/borisskert/boxfs/filesystem/windows/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/windows/FileSystemTest.java
@@ -411,6 +411,58 @@ abstract class FileSystemTest {
                     assertThat(file.toString()).isEqualTo(testFilePath);
                 }
 
+                @Nested
+                class MoveFileToAbsoluteSimpleTarget {
+                    private Path target;
+
+                    @BeforeEach
+                    void setup() throws IOException {
+                        target = fs.getPath("C:\\target.txt");
+                        Files.write(file, "Hello World!".getBytes());
+                    }
+
+                    @AfterEach
+                    void teardown() throws IOException {
+                        Files.deleteIfExists(target);
+                    }
+
+                    @Test
+                    void shouldMoveFile() throws IOException {
+                        Files.move(file, target);
+
+                        assertThat(Files.exists(target)).isTrue();
+                        assertThat(Files.readAllBytes(target)).isEqualTo("Hello World!".getBytes());
+
+                        assertThat(Files.exists(file)).isFalse();
+                    }
+                }
+
+                @Nested
+                class MoveFileToRelativeSimpleTarget {
+                    private Path target;
+
+                    @BeforeEach
+                    void setup() throws IOException {
+                        target = fs.getPath("target.txt");
+                        Files.write(file, "Hello World!".getBytes());
+                    }
+
+                    @AfterEach
+                    void teardown() throws IOException {
+                        Files.deleteIfExists(target);
+                    }
+
+                    @Test
+                    void shouldMoveFile() throws IOException {
+                        Files.move(file, target);
+
+                        assertThat(Files.exists(target)).isTrue();
+                        assertThat(Files.readAllBytes(target)).isEqualTo("Hello World!".getBytes());
+
+                        assertThat(Files.exists(file)).isFalse();
+                    }
+                }
+
                 @Test
                 void shouldNotBeAbleToGetPosixFilePermissions() {
                     assertThatThrownBy(() -> Files.getPosixFilePermissions(file)).isInstanceOf(UnsupportedOperationException.class);

--- a/src/test/java/de/borisskert/boxfs/filesystem/windows/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/windows/FileSystemTest.java
@@ -133,8 +133,24 @@ abstract class FileSystemTest {
 
             @Test
             void shouldFailWhenTryingToCopyNonExistingFile() {
-                assertThatThrownBy(() -> Files.copy(file, fs.getPath("target.txt")))
+                Path target = fs.getPath("target.txt");
+
+                assertThatThrownBy(() -> Files.copy(file, target))
                         .isInstanceOf(NoSuchFileException.class);
+
+                assertThat(Files.exists(file)).isFalse();
+                assertThat(Files.exists(target)).isFalse();
+            }
+
+            @Test
+            void shouldFailWhenTryingToMoveNonExistingFile() {
+                Path target = fs.getPath("target.txt");
+
+                assertThatThrownBy(() -> Files.move(file, target))
+                        .isInstanceOf(NoSuchFileException.class);
+
+                assertThat(Files.exists(file)).isFalse();
+                assertThat(Files.exists(target)).isFalse();
             }
 
             @Nested

--- a/src/test/java/de/borisskert/boxfs/filesystem/windows/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/windows/FileSystemTest.java
@@ -480,6 +480,24 @@ abstract class FileSystemTest {
                 }
 
                 @Test
+                void shouldNotDoAnythingWhenMoveEmptyFileToSameTarget() throws IOException {
+                    Files.move(file, file);
+
+                    assertThat(Files.exists(file)).isTrue();
+                    assertThat(Files.isDirectory(file)).isFalse();
+                    assertThat(Files.notExists(file)).isFalse();
+                    assertThat(Files.isRegularFile(file)).isTrue();
+                    assertThat(Files.isHidden(file)).isFalse();
+                    assertThat(Files.isSymbolicLink(file)).isFalse();
+                    assertThat(Files.isReadable(file)).isTrue();
+                    assertThat(Files.isWritable(file)).isTrue();
+                    assertThat(Files.isExecutable(file)).isTrue();
+                    assertThat(Files.size(file)).isEqualTo(0L);
+                    assertThat(Files.isSameFile(file, file)).isTrue();
+                    assertThat(file.toString()).isEqualTo(testFilePath);
+                }
+
+                @Test
                 void shouldNotBeAbleToGetPosixFilePermissions() {
                     assertThatThrownBy(() -> Files.getPosixFilePermissions(file)).isInstanceOf(UnsupportedOperationException.class);
                 }


### PR DESCRIPTION
## Acceptance Criteria

- [x] Move a single file from source to target
- [x] Preserve file contents byte-identical
- [x] Remove source after successful move
- [x] Support relative and absolute paths
- [x] Fail if source does not exist
- ~~Fail if source is a directory~~
- [x] Do nothing if source and target are the same path
- [x] Fail if target exists and `REPLACE_EXISTING` is not specified
- [x] Replace target if `REPLACE_EXISTING` is specified

## Technical Constraints

- [x] Must work with the BoxFS abstraction (not `java.nio.file.Files` on host paths)
- [x] Must behave consistently in BoxFS `unix`, `windows` and `macos` modes
- [x] Must not allow paths to escape the BoxFS root
- [x] Errors must surface as `IOException` (or subclasses)
- [x] Must not rely on platform-specific file permissions or executable flags
- [x] Move must be atomic where supported by the underlying BoxFS
