### PR TITLE
Move semantics & edge cases

### DIFF
--- a/src/main/java/de/borisskert/boxfs/macos/BoxFsAttributes.java
+++ b/src/main/java/de/borisskert/boxfs/macos/BoxFsAttributes.java
@@ -20,4 +20,9 @@ abstract class BoxFsAttributes implements PosixFileAttributes {
     public void setPermissions(Set<PosixFilePermission> permissions) {
         this.permissions.set(permissions);
     }
+
+    @Override
+    public Object fileKey() {
+        return System.identityHashCode(this);
+    }
 }

--- a/src/main/java/de/borisskert/boxfs/macos/BoxFsDirectoryAttributes.java
+++ b/src/main/java/de/borisskert/boxfs/macos/BoxFsDirectoryAttributes.java
@@ -53,11 +53,6 @@ class BoxFsDirectoryAttributes extends BoxFsAttributes {
     }
 
     @Override
-    public Object fileKey() {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
     public UserPrincipal owner() {
         throw new UnsupportedOperationException("Not yet implemented");
     }

--- a/src/main/java/de/borisskert/boxfs/macos/BoxFsFile.java
+++ b/src/main/java/de/borisskert/boxfs/macos/BoxFsFile.java
@@ -12,7 +12,7 @@ class BoxFsFile implements BoxFsNode {
     private byte[] content = new byte[0];
 
     private String name;
-    private final BoxFsDirectory parent;
+    private BoxFsDirectory parent;
     private final BoxFsFileSystem fileSystem;
     private final BoxFsFileAttributes attributes;
     private final BoxFsFileAttributeView view;
@@ -23,6 +23,10 @@ class BoxFsFile implements BoxFsNode {
         this.fileSystem = fileSystem;
         this.attributes = new BoxFsFileAttributes(() -> (long) content.length);
         this.view = new BoxFsFileAttributeView(this.attributes);
+    }
+
+    void setParent(BoxFsDirectory parent) {
+        this.parent = parent;
     }
 
     // -----------------------------------------------------------------------------------------------------
@@ -124,6 +128,11 @@ class BoxFsFile implements BoxFsNode {
     @Override
     public void rename(Path source, Path target) throws IOException {
         throw new UnsupportedOperationException("Cannot rename a file inside a file");
+    }
+
+    @Override
+    public void move(Path source, Path target) throws IOException {
+        throw new UnsupportedOperationException("Cannot move a file inside a file");
     }
 
     @Override

--- a/src/main/java/de/borisskert/boxfs/macos/BoxFsFile.java
+++ b/src/main/java/de/borisskert/boxfs/macos/BoxFsFile.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 class BoxFsFile implements BoxFsNode {
     private byte[] content = new byte[0];
 
-    private final String name;
+    private String name;
     private final BoxFsDirectory parent;
     private final BoxFsFileSystem fileSystem;
     private final BoxFsFileAttributes attributes;
@@ -114,6 +114,16 @@ class BoxFsFile implements BoxFsNode {
     @Override
     public Optional<BoxFsNode> parent() {
         return Optional.of(parent);
+    }
+
+    @Override
+    public void rename(String newName) {
+        this.name = newName;
+    }
+
+    @Override
+    public void rename(Path source, Path target) throws IOException {
+        throw new UnsupportedOperationException("Cannot rename a file inside a file");
     }
 
     @Override

--- a/src/main/java/de/borisskert/boxfs/macos/BoxFsFileAttributes.java
+++ b/src/main/java/de/borisskert/boxfs/macos/BoxFsFileAttributes.java
@@ -57,11 +57,6 @@ class BoxFsFileAttributes extends BoxFsAttributes {
     }
 
     @Override
-    public Object fileKey() {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
     public UserPrincipal owner() {
         throw new UnsupportedOperationException("Not yet implemented");
     }

--- a/src/main/java/de/borisskert/boxfs/macos/BoxFsFileSystem.java
+++ b/src/main/java/de/borisskert/boxfs/macos/BoxFsFileSystem.java
@@ -13,7 +13,7 @@ public class BoxFsFileSystem extends FileSystem {
 
     private final AtomicBoolean isOpen = new AtomicBoolean(true);
     private final BoxFsNode fileTree = BoxFsNode.newTree(this);
-    private final BoxFsFileSystemProvider provider = new BoxFsFileSystemProvider(fileTree, SEPARATOR);
+    private final BoxFsFileSystemProvider provider = new BoxFsFileSystemProvider(fileTree);
     private final BoxFsPath rootPath = new BoxFsRootPath(this);
 
 

--- a/src/main/java/de/borisskert/boxfs/macos/BoxFsFileSystemProvider.java
+++ b/src/main/java/de/borisskert/boxfs/macos/BoxFsFileSystemProvider.java
@@ -113,6 +113,11 @@ class BoxFsFileSystemProvider extends FileSystemProvider {
             return;
         }
 
+        Path targetParent = target.getParent();
+        if (targetParent != null && !fileTree.exists(targetParent)) {
+            throw new NoSuchFileException(targetParent.toString());
+        }
+
         moveRecursively(source, target, options);
     }
 

--- a/src/main/java/de/borisskert/boxfs/macos/BoxFsFileSystemProvider.java
+++ b/src/main/java/de/borisskert/boxfs/macos/BoxFsFileSystemProvider.java
@@ -118,6 +118,25 @@ class BoxFsFileSystemProvider extends FileSystemProvider {
             throw new NoSuchFileException(targetParent.toString());
         }
 
+        if (Objects.equals(source.getParent(), target.getParent())) {
+            boolean replaceExisting = Arrays.asList(options).contains(StandardCopyOption.REPLACE_EXISTING);
+
+            if (fileTree.exists(target)) {
+                if (replaceExisting) {
+                    if (fileTree.isDirectory(target) && hasChildren(target)) {
+                        throw new DirectoryNotEmptyException(target.toString());
+                    }
+
+                    deleteRecursively(target);
+                } else {
+                    throw new FileAlreadyExistsException(target.toString());
+                }
+            }
+
+            fileTree.rename(source, target);
+            return;
+        }
+
         moveRecursively(source, target, options);
     }
 

--- a/src/main/java/de/borisskert/boxfs/macos/BoxFsNode.java
+++ b/src/main/java/de/borisskert/boxfs/macos/BoxFsNode.java
@@ -48,4 +48,6 @@ interface BoxFsNode {
     void rename(String newName);
 
     void rename(Path source, Path target) throws IOException;
+
+    void move(Path source, Path target) throws IOException;
 }

--- a/src/main/java/de/borisskert/boxfs/macos/BoxFsNode.java
+++ b/src/main/java/de/borisskert/boxfs/macos/BoxFsNode.java
@@ -44,4 +44,8 @@ interface BoxFsNode {
     Optional<BoxFsNode> parent();
 
     BoxFsPath path();
+
+    void rename(String newName);
+
+    void rename(Path source, Path target) throws IOException;
 }

--- a/src/main/java/de/borisskert/boxfs/macos/BoxFsTree.java
+++ b/src/main/java/de/borisskert/boxfs/macos/BoxFsTree.java
@@ -118,6 +118,16 @@ class BoxFsTree implements BoxFsNode {
         return fileSystem.root();
     }
 
+    @Override
+    public void rename(String newName) {
+        throw new UnsupportedOperationException("Cannot rename the root directory");
+    }
+
+    @Override
+    public void rename(Path source, Path target) throws IOException {
+        rootDirectory.rename(source, target);
+    }
+
     private static boolean isRoot(Path path) {
         return path.isAbsolute() && path.getNameCount() < 1;
     }

--- a/src/main/java/de/borisskert/boxfs/macos/BoxFsTree.java
+++ b/src/main/java/de/borisskert/boxfs/macos/BoxFsTree.java
@@ -128,6 +128,11 @@ class BoxFsTree implements BoxFsNode {
         rootDirectory.rename(source, target);
     }
 
+    @Override
+    public void move(Path source, Path target) throws IOException {
+        rootDirectory.move(source, target);
+    }
+
     private static boolean isRoot(Path path) {
         return path.isAbsolute() && path.getNameCount() < 1;
     }

--- a/src/main/java/de/borisskert/boxfs/macos/CopyOptions.java
+++ b/src/main/java/de/borisskert/boxfs/macos/CopyOptions.java
@@ -1,0 +1,32 @@
+package de.borisskert.boxfs.macos;
+
+import java.nio.file.CopyOption;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+class CopyOptions {
+    private final Set<CopyOption> options;
+
+    private CopyOptions(Set<CopyOption> options) {
+        this.options = options;
+    }
+
+    public boolean replaceExisting() {
+        return this.options.contains(REPLACE_EXISTING);
+    }
+
+    public boolean atomicMove() {
+        return this.options.contains(ATOMIC_MOVE);
+    }
+
+    public static CopyOptions of(CopyOption... options) {
+        Set<CopyOption> optionsAsSet = new HashSet<>();
+        Collections.addAll(optionsAsSet, options);
+
+        return new CopyOptions(Collections.unmodifiableSet(optionsAsSet));
+    }
+}

--- a/src/main/java/de/borisskert/boxfs/unix/BoxFsFile.java
+++ b/src/main/java/de/borisskert/boxfs/unix/BoxFsFile.java
@@ -10,8 +10,7 @@ import java.util.Optional;
 
 class BoxFsFile implements BoxFsNode {
     private byte[] content = new byte[0];
-
-    private final String name;
+    private String name;
     private final BoxFsDirectory parent;
     private final BoxFsFileSystem fileSystem;
     private final BoxFsFileAttributes attributes;
@@ -114,6 +113,16 @@ class BoxFsFile implements BoxFsNode {
     @Override
     public Optional<BoxFsNode> parent() {
         return Optional.of(parent);
+    }
+
+    @Override
+    public void rename(String newName) {
+        this.name = newName;
+    }
+
+    @Override
+    public void rename(Path source, Path target) throws IOException {
+        throw new UnsupportedOperationException("Cannot rename a file inside a file");
     }
 
     @Override

--- a/src/main/java/de/borisskert/boxfs/unix/BoxFsFileSystemProvider.java
+++ b/src/main/java/de/borisskert/boxfs/unix/BoxFsFileSystemProvider.java
@@ -113,6 +113,11 @@ class BoxFsFileSystemProvider extends FileSystemProvider {
             return;
         }
 
+        Path targetParent = target.getParent();
+        if (targetParent != null && !fileTree.exists(targetParent)) {
+            throw new NoSuchFileException(targetParent.toString());
+        }
+
         moveRecursively(source, target, options);
     }
 

--- a/src/main/java/de/borisskert/boxfs/unix/BoxFsFileSystemProvider.java
+++ b/src/main/java/de/borisskert/boxfs/unix/BoxFsFileSystemProvider.java
@@ -113,9 +113,32 @@ class BoxFsFileSystemProvider extends FileSystemProvider {
             return;
         }
 
+        if (!fileTree.exists(source)) {
+            throw new NoSuchFileException(source.toString());
+        }
+
         Path targetParent = target.getParent();
         if (targetParent != null && !fileTree.exists(targetParent)) {
             throw new NoSuchFileException(targetParent.toString());
+        }
+
+        if (Objects.equals(source.getParent(), target.getParent())) {
+            boolean replaceExisting = Arrays.asList(options).contains(StandardCopyOption.REPLACE_EXISTING);
+
+            if (fileTree.exists(target)) {
+                if (replaceExisting) {
+                    if (fileTree.isDirectory(target) && hasChildren(target)) {
+                        throw new DirectoryNotEmptyException(target.toString());
+                    }
+
+                    deleteRecursively(target);
+                } else {
+                    throw new FileAlreadyExistsException(target.toString());
+                }
+            }
+
+            fileTree.rename(source, target);
+            return;
         }
 
         moveRecursively(source, target, options);

--- a/src/main/java/de/borisskert/boxfs/unix/BoxFsFileSystemProvider.java
+++ b/src/main/java/de/borisskert/boxfs/unix/BoxFsFileSystemProvider.java
@@ -77,14 +77,16 @@ class BoxFsFileSystemProvider extends FileSystemProvider {
 
     @Override
     public void copy(Path source, Path target, CopyOption... options) throws IOException {
+        copy(source, target, CopyOptions.of(options));
+    }
+
+    private void copy(Path source, Path target, CopyOptions options) throws IOException {
         if (source.equals(target)) {
             return;
         }
 
-        boolean replaceExisting = Arrays.asList(options).contains(StandardCopyOption.REPLACE_EXISTING);
-
         if (fileTree.exists(target)) {
-            if (replaceExisting) {
+            if (options.replaceExisting()) {
                 fileTree.delete(target);
             }
         }
@@ -122,11 +124,11 @@ class BoxFsFileSystemProvider extends FileSystemProvider {
             throw new NoSuchFileException(targetParent.toString());
         }
 
-        if (Objects.equals(source.getParent(), target.getParent())) {
-            boolean replaceExisting = Arrays.asList(options).contains(StandardCopyOption.REPLACE_EXISTING);
+        CopyOptions copyOptions = CopyOptions.of(options);
 
+        if (Objects.equals(source.getParent(), target.getParent())) {
             if (fileTree.exists(target)) {
-                if (replaceExisting) {
+                if (copyOptions.replaceExisting() || copyOptions.atomicMove()) {
                     if (fileTree.isDirectory(target) && hasChildren(target)) {
                         throw new DirectoryNotEmptyException(target.toString());
                     }
@@ -141,20 +143,28 @@ class BoxFsFileSystemProvider extends FileSystemProvider {
             return;
         }
 
-        moveRecursively(source, target, options);
+        if (copyOptions.atomicMove()) {
+            if (fileTree.exists(target)) {
+                if (fileTree.isDirectory(target) && hasChildren(target)) {
+                    throw new DirectoryNotEmptyException(target.toString());
+                }
+
+                deleteRecursively(target);
+            }
+        }
+
+        moveRecursively(source, target, copyOptions);
     }
 
-    private void moveRecursively(Path source, Path target, CopyOption... options) throws IOException {
+    private void moveRecursively(Path source, Path target, CopyOptions options) throws IOException {
         Optional<BoxFsNode> node = fileTree.readNode(source);
         if (!node.isPresent()) {
             throw new NoSuchFileException(source.toString());
         }
 
-        boolean replaceExisting = Arrays.asList(options).contains(StandardCopyOption.REPLACE_EXISTING);
-
         if (node.get().attributes().isDirectory()) {
             if (fileTree.exists(target)) {
-                if (replaceExisting) {
+                if (options.replaceExisting()) {
                     if (fileTree.isDirectory(target) && hasChildren(target)) {
                         throw new DirectoryNotEmptyException(target.toString());
                     }

--- a/src/main/java/de/borisskert/boxfs/unix/BoxFsNode.java
+++ b/src/main/java/de/borisskert/boxfs/unix/BoxFsNode.java
@@ -42,6 +42,9 @@ interface BoxFsNode {
     Collection<String> children();
 
     Optional<BoxFsNode> parent();
-
     BoxFsPath path();
+
+    void rename(String newName);
+
+    void rename(Path source, Path target) throws IOException;
 }

--- a/src/main/java/de/borisskert/boxfs/unix/BoxFsNode.java
+++ b/src/main/java/de/borisskert/boxfs/unix/BoxFsNode.java
@@ -42,6 +42,7 @@ interface BoxFsNode {
     Collection<String> children();
 
     Optional<BoxFsNode> parent();
+
     BoxFsPath path();
 
     void rename(String newName);

--- a/src/main/java/de/borisskert/boxfs/unix/BoxFsTree.java
+++ b/src/main/java/de/borisskert/boxfs/unix/BoxFsTree.java
@@ -118,6 +118,16 @@ class BoxFsTree implements BoxFsNode {
         return fileSystem.root();
     }
 
+    @Override
+    public void rename(String newName) {
+        throw new UnsupportedOperationException("Cannot rename the root directory");
+    }
+
+    @Override
+    public void rename(Path source, Path target) throws IOException {
+        rootDirectory.rename(source, target);
+    }
+
     private static boolean isRoot(Path path) {
         return path.isAbsolute() && path.getNameCount() < 1;
     }

--- a/src/main/java/de/borisskert/boxfs/unix/CopyOptions.java
+++ b/src/main/java/de/borisskert/boxfs/unix/CopyOptions.java
@@ -1,0 +1,32 @@
+package de.borisskert.boxfs.unix;
+
+import java.nio.file.CopyOption;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+class CopyOptions {
+    private final Set<CopyOption> options;
+
+    private CopyOptions(Set<CopyOption> options) {
+        this.options = options;
+    }
+
+    public boolean replaceExisting() {
+        return this.options.contains(REPLACE_EXISTING);
+    }
+
+    public boolean atomicMove() {
+        return this.options.contains(ATOMIC_MOVE);
+    }
+
+    public static CopyOptions of(CopyOption... options) {
+        Set<CopyOption> optionsAsSet = new HashSet<>();
+        Collections.addAll(optionsAsSet, options);
+
+        return new CopyOptions(Collections.unmodifiableSet(optionsAsSet));
+    }
+}

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsAttributes.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsAttributes.java
@@ -55,7 +55,7 @@ abstract class BoxFsAttributes implements BasicFileAttributes {
 
     @Override
     public Object fileKey() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return null;
     }
 
     public BoxFsBasicAttributesMap toMap() {
@@ -67,6 +67,10 @@ abstract class BoxFsAttributes implements BasicFileAttributes {
     }
 
     public void checkAccess(AccessMode[] modes) throws AccessDeniedException {
+        if (this.isDirectory()) {
+            return;
+        }
+
         for (AccessMode mode : modes) {
             if (mode == AccessMode.WRITE && this.isReadonly()) {
                 throw new AccessDeniedException("Not allowed due to read-only attribute");

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsDebugBasicFileAttributes.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsDebugBasicFileAttributes.java
@@ -1,0 +1,60 @@
+package de.borisskert.boxfs.windows;
+
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+
+class BoxFsDebugBasicFileAttributes implements BasicFileAttributes {
+
+    private final BasicFileAttributes delegate;
+    private final Object fileKey;
+
+    BoxFsDebugBasicFileAttributes(BasicFileAttributes delegate, Object fileKey) {
+        this.delegate = delegate;
+        this.fileKey = fileKey;
+    }
+
+    @Override
+    public FileTime lastModifiedTime() {
+        return delegate.lastModifiedTime();
+    }
+
+    @Override
+    public FileTime lastAccessTime() {
+        return delegate.lastAccessTime();
+    }
+
+    @Override
+    public FileTime creationTime() {
+        return delegate.creationTime();
+    }
+
+    @Override
+    public boolean isRegularFile() {
+        return delegate.isRegularFile();
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return delegate.isDirectory();
+    }
+
+    @Override
+    public boolean isSymbolicLink() {
+        return delegate.isSymbolicLink();
+    }
+
+    @Override
+    public boolean isOther() {
+        return delegate.isOther();
+    }
+
+    @Override
+    public long size() {
+        return delegate.size();
+    }
+
+    @Override
+    public Object fileKey() {
+        return fileKey;
+    }
+}

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsDirectory.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsDirectory.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttributeView;
@@ -16,19 +17,22 @@ import java.util.stream.Collectors;
 class BoxFsDirectory implements BoxFsNode {
 
     private final BoxFsFileSystem fileSystem;
-    private final BoxFsNode parent;
+    private BoxFsNode parent;
     private String name;
     private final Map<BoxFsFileName, BoxFsNode> children = new ConcurrentHashMap<>();
 
-    private final BoxFsDirectoryAttributes attributes = new BoxFsDirectoryAttributes();
-    private final BoxFsFileAttributeView attributeView = new BoxFsFileAttributeView(
-            new BoxFsDirectoryAttributes()
-    );
+    private final BoxFsDirectoryAttributes attributes;
+    private final BoxFsFileAttributeView attributeView;
+
+    private final Object fileKey;
 
     BoxFsDirectory(BoxFsFileSystem fileSystem, BoxFsNode parent, String name) {
         this.fileSystem = fileSystem;
         this.parent = parent;
         this.name = name;
+        this.fileKey = fileSystem.getOrCreateFileKey(path());
+        this.attributes = new BoxFsDirectoryAttributes();
+        this.attributeView = new BoxFsFileAttributeView(attributes());
     }
 
     @Override
@@ -240,6 +244,38 @@ class BoxFsDirectory implements BoxFsNode {
     }
 
     @Override
+    public Object fileKey() {
+        return fileKey;
+    }
+
+    @Override
+    public void move(Path source, Path target) throws IOException {
+        BoxFsNode sourceNode = readNode(source)
+                .orElseThrow(() -> new NoSuchFileException(source.toString()));
+
+        BoxFsNode targetParent = readNode(target).flatMap(BoxFsNode::parent)
+                .orElseThrow(() -> new NoSuchFileException(target.toString()));
+
+        sourceNode.removeFromParent();
+
+        String targetName = target.getFileName().toString();
+        sourceNode.rename(targetName);
+
+        targetParent.putChild(BoxFsFileName.of(targetName), sourceNode);
+    }
+
+    public void setParent(BoxFsNode parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public void removeFromParent() {
+        parent().ifPresent(parent -> {
+            parent.removeChild(this);
+        });
+    }
+
+    @Override
     public BoxFsPath path() {
         if (parent == null) {
             return fileSystem.root();
@@ -256,5 +292,14 @@ class BoxFsDirectory implements BoxFsNode {
     @Override
     public String toString() {
         return name;
+    }
+
+    public void removeChild(BoxFsNode child) {
+        this.children.values().remove(child);
+    }
+
+    public void putChild(BoxFsFileName name, BoxFsNode child) {
+        this.children.put(name, child);
+        child.setParent(this);
     }
 }

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsDirectory.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsDirectory.java
@@ -17,7 +17,7 @@ class BoxFsDirectory implements BoxFsNode {
 
     private final BoxFsFileSystem fileSystem;
     private final BoxFsNode parent;
-    private final String name;
+    private String name;
     private final Map<BoxFsFileName, BoxFsNode> children = new ConcurrentHashMap<>();
 
     private final BoxFsDirectoryAttributes attributes = new BoxFsDirectoryAttributes();
@@ -209,6 +209,34 @@ class BoxFsDirectory implements BoxFsNode {
     @Override
     public Optional<BoxFsNode> parent() {
         return Optional.ofNullable(parent);
+    }
+
+    @Override
+    public void rename(String newName) {
+        this.name = newName;
+    }
+
+    @Override
+    public void rename(Path source, Path target) throws IOException {
+        if (source.getNameCount() < 1) {
+            return;
+        }
+
+        BoxFsFileName sourceName = BoxFsFileName.of(source.getName(0).toString());
+
+        if (source.getNameCount() == 1) {
+            BoxFsNode node = children.remove(sourceName);
+            if (node != null) {
+                String targetName = target.getFileName().toString();
+                node.rename(targetName);
+                children.put(BoxFsFileName.of(targetName), node);
+            }
+        } else {
+            children.get(sourceName).rename(
+                    source.subpath(1, source.getNameCount()),
+                    target
+            );
+        }
     }
 
     @Override

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsDirectoryAttributes.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsDirectoryAttributes.java
@@ -49,6 +49,6 @@ class BoxFsDirectoryAttributes extends BoxFsAttributes {
 
     @Override
     public Object fileKey() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return null;
     }
 }

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsDrive.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsDrive.java
@@ -221,6 +221,34 @@ class BoxFsDrive implements BoxFsNode {
     }
 
     @Override
+    public void rename(String newName) {
+        throw new UnsupportedOperationException("Cannot rename the drive root");
+    }
+
+    @Override
+    public void rename(Path source, Path target) throws IOException {
+        if (source.getNameCount() < 1) {
+            return;
+        }
+
+        BoxFsFileName sourceName = BoxFsFileName.of(source.getName(0).toString());
+
+        if (source.getNameCount() == 1) {
+            BoxFsNode node = children.remove(sourceName);
+            if (node != null) {
+                String targetName = target.getFileName().toString();
+                node.rename(targetName);
+                children.put(BoxFsFileName.of(targetName), node);
+            }
+        } else {
+            children.get(sourceName).rename(
+                    source.subpath(1, source.getNameCount()),
+                    target
+            );
+        }
+    }
+
+    @Override
     public BoxFsPath path() {
         String path = driveLetter + ":\\";
         return new BoxFsPath(fileSystem, path);

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsDrive.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsDrive.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttributeView;
@@ -18,16 +19,17 @@ class BoxFsDrive implements BoxFsNode {
     private final BoxFsFileSystem fileSystem;
 
     private final Map<BoxFsFileName, BoxFsNode> children = new ConcurrentHashMap<>();
-    private final BoxFsDirectoryAttributes attributes = new BoxFsDirectoryAttributes();
-    private final BoxFsFileAttributeView attributeView = new BoxFsFileAttributeView(
-            new BoxFsDirectoryAttributes()
-    );
+    private final BoxFsDirectoryAttributes attributes;
+    private final BoxFsFileAttributeView attributeView;
+    private final Object fileKey;
 
     BoxFsDrive(BoxFsFileSystem fileSystem, char driveLetter) {
         this.fileSystem = fileSystem;
         this.driveLetter = driveLetter;
+        this.fileKey = fileSystem.getOrCreateFileKey(path());
+        this.attributes = new BoxFsDirectoryAttributes();
+        this.attributeView = new BoxFsFileAttributeView(attributes());
     }
-
 
     @Override
     public void createDirectory(Path path) throws IOException {
@@ -197,7 +199,7 @@ class BoxFsDrive implements BoxFsNode {
 
     @Override
     public byte[] content() throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Cannot read content from a drive");
     }
 
     @Override
@@ -249,6 +251,57 @@ class BoxFsDrive implements BoxFsNode {
     }
 
     @Override
+    public Object fileKey() {
+        return fileKey;
+    }
+
+    @Override
+    public void move(Path source, Path target) throws IOException {
+        BoxFsNode sourceNode = readNode(source)
+                .orElseThrow(() -> new java.nio.file.NoSuchFileException(source.toString()));
+
+        BoxFsNode targetParent = determineTargetParent(target);
+
+        sourceNode.removeFromParent();
+
+        String targetName = target.getFileName().toString();
+        sourceNode.rename(targetName);
+
+        targetParent.putChild(BoxFsFileName.of(targetName), sourceNode);
+    }
+
+    @Override
+    public void putChild(BoxFsFileName name, BoxFsNode child) {
+        this.children.put(name, child);
+    }
+
+    @Override
+    public void removeChild(BoxFsNode child) {
+        this.children.values().remove(child);
+    }
+
+    @Override
+    public void setParent(BoxFsNode parent) {
+        throw new UnsupportedOperationException("Drive cannot have a parent");
+    }
+
+    @Override
+    public void removeFromParent() {
+        throw new UnsupportedOperationException("Drive cannot have a parent");
+    }
+
+    private BoxFsNode determineTargetParent(Path target) throws NoSuchFileException {
+        Path targetParentPath = target.getParent();
+
+        if (targetParentPath == null || targetParentPath.getNameCount() == 0) {
+            return this;
+        } else {
+            return readNode(targetParentPath)
+                    .orElseThrow(() -> new NoSuchFileException(targetParentPath.toString()));
+        }
+    }
+
+    @Override
     public BoxFsPath path() {
         String path = driveLetter + ":\\";
         return new BoxFsPath(fileSystem, path);
@@ -257,5 +310,9 @@ class BoxFsDrive implements BoxFsNode {
     @Override
     public Iterable<Path> rootDirectories() {
         throw new UnsupportedOperationException("Not supported to get root directories from drive");
+    }
+
+    boolean hasSameDriveLetter(BoxFsDrive other) {
+        return driveLetter == other.driveLetter;
     }
 }

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsFile.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsFile.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 class BoxFsFile implements BoxFsNode {
     private byte[] content = new byte[0];
 
-    private final String name;
+    private String name;
     private final BoxFsNode parent;
     private final BoxFsFileSystem fileSystem;
     private final BoxFsFileAttributes attributes;
@@ -114,6 +114,16 @@ class BoxFsFile implements BoxFsNode {
     @Override
     public Optional<BoxFsNode> parent() {
         return Optional.of(parent);
+    }
+
+    @Override
+    public void rename(String newName) {
+        this.name = newName;
+    }
+
+    @Override
+    public void rename(Path source, Path target) throws IOException {
+        throw new UnsupportedOperationException("Cannot rename a file inside a file");
     }
 
     @Override

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsFile.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsFile.java
@@ -12,17 +12,19 @@ class BoxFsFile implements BoxFsNode {
     private byte[] content = new byte[0];
 
     private String name;
-    private final BoxFsNode parent;
+    private BoxFsNode parent;
     private final BoxFsFileSystem fileSystem;
     private final BoxFsFileAttributes attributes;
     private final BoxFsFileAttributeView view;
+    private final Object fileKey;
 
     BoxFsFile(BoxFsFileSystem fileSystem, BoxFsNode parent, String name) {
         this.name = name;
         this.parent = parent;
         this.fileSystem = fileSystem;
+        this.fileKey = fileSystem.getOrCreateFileKey(path());
         this.attributes = new BoxFsFileAttributes(() -> (long) content.length);
-        this.view = new BoxFsFileAttributeView(this.attributes);
+        this.view = new BoxFsFileAttributeView(attributes());
     }
 
     // -----------------------------------------------------------------------------------------------------
@@ -127,15 +129,43 @@ class BoxFsFile implements BoxFsNode {
     }
 
     @Override
+    public Object fileKey() {
+        return fileKey;
+    }
+
+    @Override
+    public void move(Path source, Path target) throws IOException {
+        throw new UnsupportedOperationException("Cannot move a file inside a file");
+    }
+
+    @Override
+    public void putChild(BoxFsFileName name, BoxFsNode child) {
+        throw new UnsupportedOperationException("Cannot put a child into a file");
+    }
+
+    @Override
+    public void removeChild(BoxFsNode child) {
+        throw new UnsupportedOperationException("Cannot remove a child from a file");
+    }
+
+    @Override
     public BoxFsPath path() {
-        return new BoxFsPath(
-                parent.path().getFileSystem(),
-                parent.path().toString() + "/" + name
-        );
+        return parent.path().resolve(name);
     }
 
     @Override
     public Iterable<Path> rootDirectories() {
         throw new UnsupportedOperationException("Cannot get root directories of a file");
+    }
+
+    public void setParent(BoxFsNode parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public void removeFromParent() {
+        parent().ifPresent(parent -> {
+            parent.removeChild(this);
+        });
     }
 }

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsFileAttributes.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsFileAttributes.java
@@ -53,6 +53,6 @@ class BoxFsFileAttributes extends BoxFsAttributes {
 
     @Override
     public Object fileKey() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return null;
     }
 }

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsFileSystemProvider.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsFileSystemProvider.java
@@ -1,6 +1,5 @@
 package de.borisskert.boxfs.windows;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsFileSystemProvider.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsFileSystemProvider.java
@@ -118,6 +118,11 @@ class BoxFsFileSystemProvider extends FileSystemProvider {
             return;
         }
 
+        Path targetParent = target.getParent();
+        if (targetParent != null && !fileTree.exists(targetParent)) {
+            throw new NoSuchFileException(targetParent.toString());
+        }
+
         moveRecursively(source, target, options);
     }
 

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsFileSystemProvider.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsFileSystemProvider.java
@@ -118,9 +118,32 @@ class BoxFsFileSystemProvider extends FileSystemProvider {
             return;
         }
 
+        if (!fileTree.exists(source)) {
+            throw new NoSuchFileException(source.toString());
+        }
+
         Path targetParent = target.getParent();
         if (targetParent != null && !fileTree.exists(targetParent)) {
             throw new NoSuchFileException(targetParent.toString());
+        }
+
+        if (Objects.equals(source.getParent(), target.getParent())) {
+            boolean replaceExisting = Arrays.asList(options).contains(StandardCopyOption.REPLACE_EXISTING);
+
+            if (fileTree.exists(target)) {
+                if (replaceExisting) {
+                    if (fileTree.isDirectory(target) && hasChildren(target)) {
+                        throw new DirectoryNotEmptyException(target.toString());
+                    }
+
+                    deleteRecursively(target);
+                } else {
+                    throw new FileAlreadyExistsException(target.toString());
+                }
+            }
+
+            fileTree.rename(source, target);
+            return;
         }
 
         moveRecursively(source, target, options);

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsNode.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsNode.java
@@ -46,4 +46,8 @@ interface BoxFsNode {
     BoxFsPath path();
 
     Iterable<Path> rootDirectories();
+
+    void rename(String newName);
+
+    void rename(Path source, Path target) throws IOException;
 }

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsNode.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsNode.java
@@ -50,4 +50,16 @@ interface BoxFsNode {
     void rename(String newName);
 
     void rename(Path source, Path target) throws IOException;
+
+    Object fileKey();
+
+    void move(Path source, Path target) throws IOException;
+
+    void putChild(BoxFsFileName name, BoxFsNode child);
+
+    void removeChild(BoxFsNode child);
+
+    void setParent(BoxFsNode parent);
+
+    void removeFromParent();
 }

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsPath.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsPath.java
@@ -68,12 +68,24 @@ class BoxFsPath implements Path {
 
     @Override
     public boolean startsWith(Path other) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        if (!(other instanceof BoxFsPath)) {
+            return false;
+        }
+
+        BoxFsPath otherPath = (BoxFsPath) other;
+        String thisPathStr = toLowerCase(this.path);
+        String otherPathStr = toLowerCase(otherPath.path);
+
+        if (otherPathStr.endsWith("\\")) {
+            return thisPathStr.startsWith(otherPathStr);
+        }
+
+        return thisPathStr.startsWith(otherPathStr + "\\") || thisPathStr.equals(otherPathStr);
     }
 
     @Override
     public boolean startsWith(String other) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return startsWith(new BoxFsPath(fileSystem, other));
     }
 
     @Override

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsTree.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsTree.java
@@ -177,6 +177,27 @@ class BoxFsTree implements BoxFsNode {
     }
 
     @Override
+    public void rename(String newName) {
+        throw new UnsupportedOperationException("Cannot rename the drive root");
+    }
+
+    @Override
+    public void rename(Path source, Path target) throws IOException {
+        Path absoluteSource = source.isAbsolute() ? source : source.toAbsolutePath();
+
+        findDrive(absoluteSource).ifPresent(drive -> {
+            try {
+                drive.rename(
+                        absoluteSource.subpath(0, absoluteSource.getNameCount()),
+                        target
+                );
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Override
     public Iterable<Path> rootDirectories() {
         return drives.values()
                 .stream()

--- a/src/main/java/de/borisskert/boxfs/windows/BoxFsTree.java
+++ b/src/main/java/de/borisskert/boxfs/windows/BoxFsTree.java
@@ -29,7 +29,7 @@ class BoxFsTree implements BoxFsNode {
     public void createDirectory(Path path) throws IOException {
         Path absolutePath = path.isAbsolute() ? path : path.toAbsolutePath();
 
-        Optional<BoxFsNode> foundDrive = findDrive(absolutePath);
+        Optional<BoxFsDrive> foundDrive = findDrive(absolutePath);
 
         if (absolutePath.getNameCount() < 1) {
             throw new UnsupportedOperationException("Not yet implemented");
@@ -48,7 +48,7 @@ class BoxFsTree implements BoxFsNode {
     public void createFile(Path path) throws IOException {
         Path absolutePath = path.isAbsolute() ? path : path.toAbsolutePath();
 
-        Optional<BoxFsNode> foundDrive = findDrive(absolutePath);
+        Optional<BoxFsDrive> foundDrive = findDrive(absolutePath);
 
         if (absolutePath.getNameCount() < 1) {
             throw new UnsupportedOperationException("Not yet implemented");
@@ -67,7 +67,7 @@ class BoxFsTree implements BoxFsNode {
     public void delete(Path path) throws IOException {
         Path absolutePath = path.isAbsolute() ? path : path.toAbsolutePath();
 
-        Optional<BoxFsNode> foundDrive = findDrive(absolutePath);
+        Optional<BoxFsDrive> foundDrive = findDrive(absolutePath);
 
         if (absolutePath.getNameCount() < 1) {
             throw new UnsupportedOperationException("Not yet implemented");
@@ -123,10 +123,10 @@ class BoxFsTree implements BoxFsNode {
     public Optional<BoxFsNode> readNode(Path path) {
         Path absolutePath = path.isAbsolute() ? path : path.toAbsolutePath();
 
-        Optional<BoxFsNode> foundDrive = findDrive(absolutePath);
+        Optional<BoxFsDrive> foundDrive = findDrive(absolutePath);
 
         if (absolutePath.getNameCount() < 1) {
-            return foundDrive;
+            return foundDrive.map(d -> (BoxFsNode) d);
         }
 
         return foundDrive
@@ -137,7 +137,7 @@ class BoxFsTree implements BoxFsNode {
     public void writeContent(Path path, ByteBuffer buffer) {
         Path absolutePath = path.isAbsolute() ? path : path.toAbsolutePath();
 
-        Optional<BoxFsNode> foundDrive = findDrive(absolutePath);
+        Optional<BoxFsDrive> foundDrive = findDrive(absolutePath);
 
         if (absolutePath.getNameCount() < 1) {
             throw new IllegalArgumentException("Path must not be a drive root");
@@ -198,6 +198,49 @@ class BoxFsTree implements BoxFsNode {
     }
 
     @Override
+    public Object fileKey() {
+        throw new UnsupportedOperationException("No fileKey for BoxFsTree");
+    }
+
+    @Override
+    public void move(Path source, Path target) throws IOException {
+        Path absoluteSource = source.isAbsolute() ? source : source.toAbsolutePath();
+        Path absoluteTarget = target.isAbsolute() ? target : target.toAbsolutePath();
+
+        BoxFsDrive sourceDrive = findDrive(absoluteSource).orElseThrow(() -> new RuntimeException("Not yet implemented"));
+        BoxFsDrive targetDrive = findDrive(absoluteTarget).orElseThrow(() -> new RuntimeException("Not yet implemented"));
+
+        if (sourceDrive.hasSameDriveLetter(targetDrive)) {
+            sourceDrive.move(
+                    absoluteSource.subpath(0, absoluteSource.getNameCount()),
+                    absoluteTarget.subpath(0, absoluteTarget.getNameCount())
+            );
+        } else {
+            throw new RuntimeException("Not yet implemented");
+        }
+    }
+
+    @Override
+    public void putChild(BoxFsFileName name, BoxFsNode child) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public void removeChild(BoxFsNode child) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public void setParent(BoxFsNode parent) {
+        throw new UnsupportedOperationException("Tree node has no parent");
+    }
+
+    @Override
+    public void removeFromParent() {
+        throw new UnsupportedOperationException("Tree node has no parent");
+    }
+
+    @Override
     public Iterable<Path> rootDirectories() {
         return drives.values()
                 .stream()
@@ -205,7 +248,7 @@ class BoxFsTree implements BoxFsNode {
                 .collect(Collectors.toList());
     }
 
-    private Optional<BoxFsNode> findDrive(Path path) {
+    private Optional<BoxFsDrive> findDrive(Path path) {
         String absolutePath = path.toString();
 
         char driveLetter = parseDriveLetter(absolutePath);

--- a/src/main/java/de/borisskert/boxfs/windows/CopyOptions.java
+++ b/src/main/java/de/borisskert/boxfs/windows/CopyOptions.java
@@ -1,0 +1,32 @@
+package de.borisskert.boxfs.windows;
+
+import java.nio.file.CopyOption;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+class CopyOptions {
+    private final Set<CopyOption> options;
+
+    private CopyOptions(Set<CopyOption> options) {
+        this.options = options;
+    }
+
+    public boolean replaceExisting() {
+        return this.options.contains(REPLACE_EXISTING);
+    }
+
+    public boolean atomicMove() {
+        return this.options.contains(ATOMIC_MOVE);
+    }
+
+    public static CopyOptions of(CopyOption... options) {
+        Set<CopyOption> optionsAsSet = new HashSet<>();
+        Collections.addAll(optionsAsSet, options);
+
+        return new CopyOptions(Collections.unmodifiableSet(optionsAsSet));
+    }
+}

--- a/src/test/java/de/borisskert/boxfs/filesystem/macos/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/macos/FileSystemTest.java
@@ -1361,6 +1361,14 @@ abstract class FileSystemTest {
                                 }
 
                                 @Test
+                                void shouldFailToMoveIfNestedTargetDoesNotExist() throws IOException {
+                                    Path target = fs.getPath("/nested/targetdir");
+
+                                    assertThatThrownBy(() -> Files.move(dir, target))
+                                            .isInstanceOf(NoSuchFileException.class);
+                                }
+
+                                @Test
                                 void shouldFailToMoveIfTargetExists() throws IOException {
                                     Path target = fs.getPath("/targetdir");
                                     Files.createDirectories(target);

--- a/src/test/java/de/borisskert/boxfs/filesystem/macos/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/macos/FileSystemTest.java
@@ -1361,7 +1361,7 @@ abstract class FileSystemTest {
                                 }
 
                                 @Test
-                                void shouldFailToMoveIfNestedTargetDoesNotExist() throws IOException {
+                                void shouldFailToMoveIfNestedTargetDoesNotExist() {
                                     Path target = fs.getPath("/nested/targetdir");
 
                                     assertThatThrownBy(() -> Files.move(dir, target))

--- a/src/test/java/de/borisskert/boxfs/filesystem/unix/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/unix/FileSystemTest.java
@@ -233,7 +233,6 @@ abstract class FileSystemTest {
                     }
 
                     @Test
-                    @Disabled
                     void shouldThrowWhenCheckingForSameFileWhichDoesntExist() {
                         assertThatThrownBy(() -> Files.isSameFile(pathWithDifferentCase, file)).isInstanceOf(NoSuchFileException.class);
                     }
@@ -796,6 +795,14 @@ abstract class FileSystemTest {
                         assertThat(Files.isSameFile(secondFile, secondFile)).isTrue();
                         assertThat(secondFile.toString()).isEqualTo(secondFilePath);
                     }
+
+                    @Test
+                    void shouldMoveFileAtomics() throws IOException {
+                        Files.move(file, secondFile, StandardCopyOption.ATOMIC_MOVE);
+
+                        assertThat(Files.exists(secondFile)).isTrue();
+                        assertThat(Files.exists(file)).isFalse();
+                    }
                 }
             }
         }
@@ -1175,6 +1182,55 @@ abstract class FileSystemTest {
                     }
 
                     @Nested
+                    class MoveDirectoryAtomic {
+                        String targetDirPath = "/targetdir";
+                        Path target;
+                        Path targetFile;
+
+                        @BeforeEach
+                        void setup() throws IOException {
+                            Files.write(fileInDir, "Hello World!".getBytes());
+
+                            target = fs.getPath(targetDirPath);
+                            Files.createDirectories(target);
+
+                            targetFile = target.resolve("testfile.txt");
+
+                            Files.move(dir, target, StandardCopyOption.ATOMIC_MOVE);
+                        }
+
+                        @AfterEach
+                        void teardown() throws IOException {
+                            Files.move(target, dir);
+                        }
+
+                        @Test
+                        void shouldMoveDirectoryAndContentsToTarget() throws IOException {
+                            assertThat(Files.exists(target)).isTrue();
+                            assertThat(Files.isDirectory(target)).isTrue();
+                            assertThat(Files.isRegularFile(target)).isFalse();
+
+                            assertThat(Files.exists(targetFile)).isTrue();
+                            assertThat(Files.isDirectory(targetFile)).isFalse();
+                            assertThat(Files.isRegularFile(targetFile)).isTrue();
+
+                            assertThat(Files.size(targetFile)).isEqualTo(12L);
+                            assertThat(Files.readAllBytes(targetFile)).isEqualTo("Hello World!".getBytes());
+                        }
+
+                        @Test
+                        void shouldRemoveDirectoryAndContentsFromSource() {
+                            assertThat(Files.exists(dir)).isFalse();
+                            assertThat(Files.isDirectory(dir)).isFalse();
+                            assertThat(Files.isRegularFile(dir)).isFalse();
+
+                            assertThat(Files.exists(fileInDir)).isFalse();
+                            assertThat(Files.isDirectory(fileInDir)).isFalse();
+                            assertThat(Files.isRegularFile(fileInDir)).isFalse();
+                        }
+                    }
+
+                    @Nested
                     class CreateSubDirectory {
                         static final String SUBDIR_NAME = "subdir";
                         Path subdir;
@@ -1484,6 +1540,19 @@ abstract class FileSystemTest {
                     void shouldCopyDirectory() throws IOException {
                         assertThat(Files.exists(target)).isTrue();
                         assertThat(Files.isDirectory(target)).isTrue();
+                        assertThat(Files.notExists(target)).isFalse();
+                        assertThat(Files.isRegularFile(target)).isFalse();
+                        assertThat(Files.isHidden(target)).isFalse();
+                        assertThat(Files.isSymbolicLink(target)).isFalse();
+                        assertThat(Files.isReadable(target)).isTrue();
+                        assertThat(Files.isWritable(target)).isTrue();
+                        assertThat(Files.isExecutable(target)).isTrue();
+                    }
+
+                    @Test
+                    void shouldLeaveSourceDirectory() throws IOException {
+                        assertThat(Files.exists(dir)).isTrue();
+                        assertThat(Files.isDirectory(dir)).isTrue();
                         assertThat(Files.notExists(dir)).isFalse();
                         assertThat(Files.isRegularFile(dir)).isFalse();
                         assertThat(Files.isHidden(dir)).isFalse();
@@ -1513,13 +1582,13 @@ abstract class FileSystemTest {
                     void shouldCopyDirectory() throws IOException {
                         assertThat(Files.exists(target)).isTrue();
                         assertThat(Files.isDirectory(target)).isTrue();
-                        assertThat(Files.notExists(dir)).isFalse();
-                        assertThat(Files.isRegularFile(dir)).isFalse();
-                        assertThat(Files.isHidden(dir)).isFalse();
-                        assertThat(Files.isSymbolicLink(dir)).isFalse();
-                        assertThat(Files.isReadable(dir)).isTrue();
-                        assertThat(Files.isWritable(dir)).isTrue();
-                        assertThat(Files.isExecutable(dir)).isTrue();
+                        assertThat(Files.notExists(target)).isFalse();
+                        assertThat(Files.isRegularFile(target)).isFalse();
+                        assertThat(Files.isHidden(target)).isFalse();
+                        assertThat(Files.isSymbolicLink(target)).isFalse();
+                        assertThat(Files.isReadable(target)).isTrue();
+                        assertThat(Files.isWritable(target)).isTrue();
+                        assertThat(Files.isExecutable(target)).isTrue();
                     }
                 }
 
@@ -1696,13 +1765,13 @@ abstract class FileSystemTest {
                     @Test
                     void shouldFailWhenTryingToCopySecondDirectoryToOtherWithoutReplace() {
                         assertThatThrownBy(() -> Files.copy(secondDir, dir))
-                                .isInstanceOf(IOException.class);
+                                .isInstanceOf(FileAlreadyExistsException.class);
                     }
 
                     @Test
                     void shouldFailWhenTryingToCopyOtherDirectoryToSecondWithoutReplace() {
                         assertThatThrownBy(() -> Files.copy(dir, secondDir))
-                                .isInstanceOf(IOException.class);
+                                .isInstanceOf(FileAlreadyExistsException.class);
                     }
 
                     @Test

--- a/src/test/java/de/borisskert/boxfs/filesystem/unix/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/unix/FileSystemTest.java
@@ -1370,6 +1370,13 @@ abstract class FileSystemTest {
                                     }
                                 }
 
+                                @Test
+                                void shouldFailToMoveIfNestedTargetDoesNotExist() {
+                                    Path target = fs.getPath("/nested/targetdir");
+
+                                    assertThatThrownBy(() -> Files.move(dir, target))
+                                            .isInstanceOf(NoSuchFileException.class);
+                                }
 
                                 @Test
                                 void shouldFailToMoveIfTargetExists() throws IOException {

--- a/src/test/java/de/borisskert/boxfs/filesystem/windows/BoxFsTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/windows/BoxFsTest.java
@@ -1,14 +1,21 @@
 package de.borisskert.boxfs.filesystem.windows;
 
 import de.borisskert.boxfs.BoxFs;
+import de.borisskert.boxfs.windows.BoxFsTestingBasicFileAttributes;
 import org.junit.jupiter.api.DisplayName;
 
 import java.nio.file.FileSystem;
+import java.nio.file.attribute.BasicFileAttributes;
 
 @DisplayName("Windows FileSystemTest (BoxFs)")
 class BoxFsTest extends FileSystemTest {
     @Override
     FileSystem getFs() {
         return BoxFs.windows();
+    }
+
+    @Override
+    Class<? extends BasicFileAttributes> fileAttributesClassForDebug() {
+        return BoxFsTestingBasicFileAttributes.class;
     }
 }

--- a/src/test/java/de/borisskert/boxfs/filesystem/windows/DefaultTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/windows/DefaultTest.java
@@ -1,5 +1,6 @@
 package de.borisskert.boxfs.filesystem.windows;
 
+import de.borisskert.boxfs.wrapped.windows.WrappedBasicFileAttributes;
 import de.borisskert.boxfs.wrapped.windows.WrappedFileSystem;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -7,12 +8,20 @@ import org.junit.jupiter.api.condition.OS;
 
 import java.io.IOException;
 import java.nio.file.FileSystem;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
 
 @EnabledOnOs(OS.WINDOWS)
 @DisplayName("Windows FileSystemTest (Windows Wrapped FileSystem)")
 class DefaultTest extends FileSystemTest {
     @Override
     FileSystem getFs() throws IOException {
+        deleteRecursivelyIfExists(Paths.get("C:\\Temp\\boxfs-test"));
         return WrappedFileSystem.create("C:\\Temp\\boxfs-test");
+    }
+
+    @Override
+    Class<? extends BasicFileAttributes> fileAttributesClassForDebug() {
+        return WrappedBasicFileAttributes.class;
     }
 }

--- a/src/test/java/de/borisskert/boxfs/filesystem/windows/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/windows/FileSystemTest.java
@@ -1321,6 +1321,14 @@ abstract class FileSystemTest {
                                 }
 
                                 @Test
+                                void shouldFailToMoveIfNestedTargetDoesNotExist() {
+                                    Path target = fs.getPath("C:\\nested\\targetdir");
+
+                                    assertThatThrownBy(() -> Files.move(dir, target))
+                                            .isInstanceOf(NoSuchFileException.class);
+                                }
+
+                                @Test
                                 void shouldFailToMoveIfTargetExists() throws IOException {
                                     Path target = fs.getPath("C:\\targetdir");
                                     Files.createDirectories(target);

--- a/src/test/java/de/borisskert/boxfs/filesystem/windows/FileSystemTest.java
+++ b/src/test/java/de/borisskert/boxfs/filesystem/windows/FileSystemTest.java
@@ -1,12 +1,10 @@
 package de.borisskert.boxfs.filesystem.windows;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Collections;
 import java.util.HashSet;
@@ -20,6 +18,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 abstract class FileSystemTest {
 
     abstract FileSystem getFs() throws IOException;
+
+    abstract Class<? extends BasicFileAttributes> fileAttributesClassForDebug();
 
     private FileSystem fs;
 
@@ -108,6 +108,12 @@ abstract class FileSystemTest {
             }
 
             @Test
+            void shouldNotSupportFileKeys() {
+                assertThatThrownBy(() -> Files.readAttributes(file, BasicFileAttributes.class).fileKey())
+                        .isInstanceOf(NoSuchFileException.class);
+            }
+
+            @Test
             void shouldNotFindAnyFilesInRootDirectory() throws IOException {
                 try (DirectoryStream<Path> paths = Files.newDirectoryStream(root)) {
                     Iterator<Path> iterator = paths.iterator();
@@ -178,6 +184,11 @@ abstract class FileSystemTest {
                     assertThat(Files.isExecutable(file)).isTrue();
                     assertThat(Files.size(file)).isEqualTo(0);
                     assertThat(Files.isSameFile(file, file)).isTrue();
+                }
+
+                @Test
+                void shouldNotSupportFileKeys() throws IOException {
+                    assertThat(Files.readAttributes(file, BasicFileAttributes.class).fileKey()).isNull();
                 }
 
                 @Test
@@ -358,11 +369,15 @@ abstract class FileSystemTest {
                 @Nested
                 class CopyFileToAbsoluteSimpleTarget {
                     private Path target;
+                    private Object originalFileKey;
 
                     @BeforeEach
                     void setup() throws IOException {
                         target = fs.getPath("C:\\target.txt");
                         Files.write(file, "Hello World!".getBytes());
+                        originalFileKey = Files.readAttributes(file, fileAttributesClassForDebug()).fileKey();
+
+                        Files.copy(file, target);
                     }
 
                     @AfterEach
@@ -372,24 +387,36 @@ abstract class FileSystemTest {
 
                     @Test
                     void shouldCopyFile() throws IOException {
-                        Files.copy(file, target);
-
                         assertThat(Files.exists(target)).isTrue();
                         assertThat(Files.readAllBytes(target)).isEqualTo("Hello World!".getBytes());
 
                         assertThat(Files.exists(file)).isTrue();
                         assertThat(Files.readAllBytes(file)).isEqualTo("Hello World!".getBytes());
+                    }
+
+                    @Test
+                    void shouldCreateNewFileKey() throws IOException {
+                        Object newFileKey = Files.readAttributes(target, fileAttributesClassForDebug()).fileKey();
+
+                        assertThat(originalFileKey).isNotNull();
+                        assertThat(newFileKey).isNotNull();
+
+                        assertThat(newFileKey).isNotEqualTo(originalFileKey);
                     }
                 }
 
                 @Nested
                 class CopyFileToRelativeSimpleTarget {
                     private Path target;
+                    private Object originalFileKey;
 
                     @BeforeEach
                     void setup() throws IOException {
                         target = fs.getPath("target.txt");
                         Files.write(file, "Hello World!".getBytes());
+                        originalFileKey = Files.readAttributes(file, fileAttributesClassForDebug()).fileKey();
+
+                        Files.copy(file, target);
                     }
 
                     @AfterEach
@@ -399,13 +426,21 @@ abstract class FileSystemTest {
 
                     @Test
                     void shouldCopyFile() throws IOException {
-                        Files.copy(file, target);
-
                         assertThat(Files.exists(target)).isTrue();
                         assertThat(Files.readAllBytes(target)).isEqualTo("Hello World!".getBytes());
 
                         assertThat(Files.exists(file)).isTrue();
                         assertThat(Files.readAllBytes(file)).isEqualTo("Hello World!".getBytes());
+                    }
+
+                    @Test
+                    void shouldCreateNewFileKey() throws IOException {
+                        Object newFileKey = Files.readAttributes(target, fileAttributesClassForDebug()).fileKey();
+
+                        assertThat(originalFileKey).isNotNull();
+                        assertThat(newFileKey).isNotNull();
+
+                        assertThat(newFileKey).isNotEqualTo(originalFileKey);
                     }
                 }
 
@@ -430,52 +465,79 @@ abstract class FileSystemTest {
                 @Nested
                 class MoveFileToAbsoluteSimpleTarget {
                     private Path target;
+                    private Object originalFileKey;
 
                     @BeforeEach
                     void setup() throws IOException {
                         target = fs.getPath("C:\\target.txt");
+                        originalFileKey = Files.readAttributes(file, fileAttributesClassForDebug()).fileKey();
+
                         Files.write(file, "Hello World!".getBytes());
+
+                        Files.move(file, target);
                     }
 
                     @AfterEach
                     void teardown() throws IOException {
-                        Files.deleteIfExists(target);
+                        Files.move(target, file);
                     }
 
                     @Test
                     void shouldMoveFile() throws IOException {
-                        Files.move(file, target);
-
                         assertThat(Files.exists(target)).isTrue();
                         assertThat(Files.readAllBytes(target)).isEqualTo("Hello World!".getBytes());
 
                         assertThat(Files.exists(file)).isFalse();
+                    }
+
+                    @Test
+                    @DisplayName("should preserve fileKey of after move within same filesystem")
+                    void shouldPreserveFileKey() throws IOException {
+                        Object newFileKey = Files.readAttributes(target, fileAttributesClassForDebug()).fileKey();
+
+                        assertThat(originalFileKey).isNotNull();
+                        assertThat(newFileKey).isNotNull();
+
+                        assertThat(newFileKey).isEqualTo(originalFileKey);
                     }
                 }
 
                 @Nested
                 class MoveFileToRelativeSimpleTarget {
                     private Path target;
+                    private Object originalFileKey;
 
                     @BeforeEach
                     void setup() throws IOException {
                         target = fs.getPath("target.txt");
                         Files.write(file, "Hello World!".getBytes());
+                        originalFileKey = Files.readAttributes(file, fileAttributesClassForDebug()).fileKey();
+
+                        Files.move(file, target);
                     }
 
                     @AfterEach
                     void teardown() throws IOException {
-                        Files.deleteIfExists(target);
+                        Files.move(target, file);
                     }
 
                     @Test
                     void shouldMoveFile() throws IOException {
-                        Files.move(file, target);
-
                         assertThat(Files.exists(target)).isTrue();
                         assertThat(Files.readAllBytes(target)).isEqualTo("Hello World!".getBytes());
 
                         assertThat(Files.exists(file)).isFalse();
+                    }
+
+                    @Test
+                    @DisplayName("should preserve fileKey of after move within same filesystem")
+                    void shouldPreserveFileKey() throws IOException {
+                        Object newFileKey = Files.readAttributes(target, fileAttributesClassForDebug()).fileKey();
+
+                        assertThat(originalFileKey).isNotNull();
+                        assertThat(newFileKey).isNotNull();
+
+                        assertThat(newFileKey).isEqualTo(originalFileKey);
                     }
                 }
 
@@ -781,6 +843,12 @@ abstract class FileSystemTest {
             }
 
             @Test
+            void shouldNotSupportFileKeys() {
+                assertThatThrownBy(() -> Files.readAttributes(dir, BasicFileAttributes.class).fileKey())
+                        .isInstanceOf(NoSuchFileException.class);
+            }
+
+            @Test
             void shouldFailWhenTryingToEstimateSize() {
                 assertThatThrownBy(() -> Files.size(dir)).isInstanceOf(NoSuchFileException.class);
             }
@@ -831,6 +899,11 @@ abstract class FileSystemTest {
                     assertThat(Files.isReadable(dir)).isTrue();
                     assertThat(Files.isWritable(dir)).isTrue();
                     assertThat(Files.isExecutable(dir)).isTrue();
+                }
+
+                @Test
+                void shouldNotSupportFileKeys() throws IOException {
+                    assertThat(Files.readAttributes(dir, BasicFileAttributes.class).fileKey()).isNull();
                 }
 
                 @Test
@@ -1030,10 +1103,17 @@ abstract class FileSystemTest {
                     class CopyDirectory {
                         String targetDirPath = "C:\\targetdir";
                         Path target;
+                        Path targetFile;
+
+                        Object originalDirKey;
 
                         @BeforeEach
                         void setup() throws IOException {
                             target = fs.getPath(targetDirPath);
+                            targetFile = target.resolve("testfile.txt");
+
+                            originalDirKey = Files.readAttributes(dir, fileAttributesClassForDebug()).fileKey();
+
                             Files.copy(dir, target);
                         }
 
@@ -1070,11 +1150,9 @@ abstract class FileSystemTest {
 
                         @Test
                         void shouldNotCopyContainedFile() {
-                            Path fileInTarget = target.resolve("testfile.txt");
-
-                            assertThat(Files.exists(fileInTarget)).isFalse();
-                            assertThat(Files.isRegularFile(fileInTarget)).isFalse();
-                            assertThatThrownBy(() -> Files.size(fileInTarget)).isInstanceOf(NoSuchFileException.class);
+                            assertThat(Files.exists(targetFile)).isFalse();
+                            assertThat(Files.isRegularFile(targetFile)).isFalse();
+                            assertThatThrownBy(() -> Files.size(targetFile)).isInstanceOf(NoSuchFileException.class);
                         }
 
                         @Test
@@ -1083,13 +1161,27 @@ abstract class FileSystemTest {
                             assertThat(Files.isRegularFile(fileInDir)).isTrue();
                             assertThat(Files.size(fileInDir)).isEqualTo(0);
                         }
+
+                        @Test
+                        void shouldCreateNewFileKeys() throws IOException {
+                            Object newDirKey = Files.readAttributes(target, fileAttributesClassForDebug()).fileKey();
+
+                            assertThat(originalDirKey).isNotNull();
+
+                            assertThat(newDirKey).isNotNull();
+
+                            assertThat(newDirKey).isNotEqualTo(originalDirKey);
+                        }
                     }
 
                     @Nested
                     class MoveDirectory {
-                        String targetDirPath = "/targetdir";
+                        String targetDirPath = "C:\\targetdir";
                         Path target;
                         Path targetFile;
+
+                        Object originalDirKey;
+                        Object originalFileKey;
 
                         @BeforeEach
                         void setup() throws IOException {
@@ -1097,6 +1189,9 @@ abstract class FileSystemTest {
 
                             target = fs.getPath(targetDirPath);
                             targetFile = target.resolve("testfile.txt");
+
+                            originalDirKey = Files.readAttributes(dir, fileAttributesClassForDebug()).fileKey();
+                            originalFileKey = Files.readAttributes(fileInDir, fileAttributesClassForDebug()).fileKey();
 
                             Files.move(dir, target);
                         }
@@ -1129,6 +1224,22 @@ abstract class FileSystemTest {
                             assertThat(Files.exists(fileInDir)).isFalse();
                             assertThat(Files.isDirectory(fileInDir)).isFalse();
                             assertThat(Files.isRegularFile(fileInDir)).isFalse();
+                        }
+
+                        @Test
+                        @DisplayName("should preserve fileKey of directory and its content after move within same filesystem")
+                        void shouldPreserveFileKey() throws IOException {
+                            Object newDirKey = Files.readAttributes(target, fileAttributesClassForDebug()).fileKey();
+                            Object newFileKey = Files.readAttributes(targetFile, fileAttributesClassForDebug()).fileKey();
+
+                            assertThat(originalDirKey).isNotNull();
+                            assertThat(originalFileKey).isNotNull();
+
+                            assertThat(newDirKey).isNotNull();
+                            assertThat(newFileKey).isNotNull();
+
+                            assertThat(newDirKey).isEqualTo(originalDirKey);
+                            assertThat(newFileKey).isEqualTo(originalFileKey);
                         }
                     }
 
@@ -1914,7 +2025,7 @@ abstract class FileSystemTest {
         }
     }
 
-    private static void deleteRecursivelyIfExists(Path path) throws IOException {
+    static void deleteRecursivelyIfExists(Path path) throws IOException {
         Path absolutePath = path.toAbsolutePath();
 
         if (!Files.exists(absolutePath)) {

--- a/src/test/java/de/borisskert/boxfs/windows/BoxFsTestingBasicFileAttributes.java
+++ b/src/test/java/de/borisskert/boxfs/windows/BoxFsTestingBasicFileAttributes.java
@@ -1,0 +1,14 @@
+package de.borisskert.boxfs.windows;
+
+import java.nio.file.attribute.BasicFileAttributes;
+
+/**
+ * Debugging wrapper for {@link BasicFileAttributes} that provides additional functionality for testing purposes.
+ * We do not want to make {@link BoxFsDebugBasicFileAttributes} public so we use this class as a wrapper.
+ */
+public class BoxFsTestingBasicFileAttributes extends BoxFsDebugBasicFileAttributes {
+
+    BoxFsTestingBasicFileAttributes(BasicFileAttributes delegate, Object fileKey) {
+        super(delegate, fileKey);
+    }
+}

--- a/src/test/java/de/borisskert/boxfs/wrapped/windows/WrappedBasicFileAttributes.java
+++ b/src/test/java/de/borisskert/boxfs/wrapped/windows/WrappedBasicFileAttributes.java
@@ -1,0 +1,60 @@
+package de.borisskert.boxfs.wrapped.windows;
+
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+
+public class WrappedBasicFileAttributes implements BasicFileAttributes {
+
+    private final BasicFileAttributes delegate;
+    private final Object fileKey;
+
+    public WrappedBasicFileAttributes(BasicFileAttributes delegate, Object fileKey) {
+        this.delegate = delegate;
+        this.fileKey = fileKey;
+    }
+
+    @Override
+    public FileTime lastModifiedTime() {
+        return delegate.lastModifiedTime();
+    }
+
+    @Override
+    public FileTime lastAccessTime() {
+        return delegate.lastAccessTime();
+    }
+
+    @Override
+    public FileTime creationTime() {
+        return delegate.creationTime();
+    }
+
+    @Override
+    public boolean isRegularFile() {
+        return delegate.isRegularFile();
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return delegate.isDirectory();
+    }
+
+    @Override
+    public boolean isSymbolicLink() {
+        return delegate.isSymbolicLink();
+    }
+
+    @Override
+    public boolean isOther() {
+        return delegate.isOther();
+    }
+
+    @Override
+    public long size() {
+        return delegate.size();
+    }
+
+    @Override
+    public Object fileKey() {
+        return fileKey;
+    }
+}

--- a/src/test/java/de/borisskert/boxfs/wrapped/windows/WrappedFileSystemProvider.java
+++ b/src/test/java/de/borisskert/boxfs/wrapped/windows/WrappedFileSystemProvider.java
@@ -95,6 +95,7 @@ public class WrappedFileSystemProvider extends FileSystemProvider {
     @Override
     public void move(Path source, Path target, CopyOption... options) throws IOException {
         delegate.move(unwrap(source), unwrap(target), options);
+        fs.moveFileKey(source, target);
     }
 
     @Override
@@ -132,6 +133,11 @@ public class WrappedFileSystemProvider extends FileSystemProvider {
             Class<A> type,
             LinkOption... options
     ) throws IOException {
+        if (WrappedBasicFileAttributes.class.isAssignableFrom(type)) {
+            BasicFileAttributes attributes = delegate.readAttributes(unwrap(path), BasicFileAttributes.class, options);
+            return (A) new WrappedBasicFileAttributes(attributes, fs.getOrCreateFileKey(path));
+        }
+
         return delegate.readAttributes(unwrap(path), type, options);
     }
 


### PR DESCRIPTION
## Acceptance Criteria

- [x] Moving a file or directory within the same BoxFS may be optimized to a rename
- [x] Moving across directories must preserve correctness even if atomic rename is not possible
- [ ] Partial moves must not leave the filesystem in an inconsistent state
- [ ] On failure, either:
  - [ ] source remains unchanged, or
  - [ ] target is fully removed

## Technical Constraints

- [ ] Must not expose partially moved directory trees
- [ ] Must clean up intermediate state on failure
- [ ] Must surface errors as `IOException` (or subclasses)
- [ ] Behavior must match `java.nio.file.Files.move` as closely as possible